### PR TITLE
feat: implemented createdb and dropdb bins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ pgtools.dropdb(config, dbname [, cb(err)])
 
     A callback that takes an error argument. If cb is omitted the
     function will return a Promise.
+
+## Bins
+
+`pgtools` installs two useful binaries:
+
+* `createdbjs`: which emulates pgtools' `createdb` functionality.
+* `dropdbjs`: which emulates pgtools' `dropdb` functionality.

--- a/dropdb.js
+++ b/dropdb.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
-var createdb = require('./').createdb;
+var dropdb = require('./').dropdb;
 var yargs = require('./lib/build-yargs')()
 var argv = yargs.argv;
 
-createdb({
+dropdb({
   host: argv.host,
   port: argv.port,
   user: argv.user
 }, argv._[0], function (err, res) {
   if (err) die(err, argv)
-  else if (!argv.silent) console.log('created database "' + argv._[0] + '"')
+  else if (!argv.silent) console.log('dropped database "' + argv._[0] + '"')
 })
 
 function die (err, argv) {

--- a/lib/build-yargs.js
+++ b/lib/build-yargs.js
@@ -1,0 +1,26 @@
+module.exports = function () {
+  return require('yargs')
+    .usage('$0 [options] <dbname>')
+    .option('host', {
+      alias: 'h',
+      default: '127.0.0.1',
+      describe: 'database server host or socket directory'
+    })
+    .option('user', {
+      alias: 'u',
+      default: 'postgres',
+      describe: 'user name to connect as'
+    })
+    .option('port', {
+      alias: 'p',
+      default: 5432,
+      describe: 'database server port'
+    })
+    .option('silent', {
+      default: false,
+      describe: 'should we output to stdout'
+    })
+    .demand(1, 'you must provide a database name')
+    .help()
+    .version()
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,13 @@
   "main": "index.js",
   "dependencies": {
     "bluebird": "^3.3.5",
-    "commander": "^2.9.0",
-    "pg": "^4.4.0",
-    "pg-connection-string": "^0.1.3"
+    "pg": "^6.1.0",
+    "pg-connection-string": "^0.1.3",
+    "yargs": "^5.0.0"
+  },
+  "bin": {
+    "createdbjs": "./createdb.js",
+    "dropdbjs": "./createdb.js"
   },
   "devDependencies": {},
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -34,4 +34,3 @@ dropdb(config, 'pgtools-test', function (err, res) {
     });
   });
 });
-


### PR DESCRIPTION
Hey @olalonde hope I'm not being too forward; I'm using Docker to make our postgres development environments standardized at npm; I love the idea of having a pure-js implementation of `pgtools` which we can use in our npm-scripts to setup and teardown our testing environments.

In this pull request:
- I've gone ahead and implemented `createdbjs` and `dropdbjs` as bins.
- I switched over to `yargs`, which I maintain, mainly because it meant I could hammer things out really fast.
- I added these bins to the package.json, so that they get added to `.bin`.
