### PR TITLE
fix: non-pg error not handled properly

### DIFF
--- a/createdb.js
+++ b/createdb.js
@@ -14,7 +14,7 @@ createdb({
 
 function die (err, argv) {
   if (err) {
-    if (!argv.silent) console.log(err.pgErr.toString());
+    if (!argv.silent) console.log(err.pgErr ? err.pgErr.toString() : err.toString());
     process.exit(-1);
   }
 }

--- a/dropdb.js
+++ b/dropdb.js
@@ -14,7 +14,7 @@ dropdb({
 
 function die (err, argv) {
   if (err) {
-    if (!argv.silent) console.log(err.pgErr.toString());
+    if (!argv.silent) console.log(err.pgErr ? err.pgErr.toString() : err.toString());
     process.exit(-1);
   }
 }


### PR DESCRIPTION
`````` sh
/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/node_modules/bluebird/js/release/async.js:61
        fn = function () { throw arg; };
                                 ^
TypeError: Cannot call method 'toString' of undefined
    at die (/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/createdb.js:17:45)
    at /Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/createdb.js:11:12
    at tryCatcher (/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/node_modules/bluebird/js/release/util.js:16:23)
    at Promise.errorAdapter [as _rejectionHandler0] (/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/node_modules/bluebird/js/release/nodeify.js:35:34)
    at Promise._settlePromise (/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/node_modules/bluebird/js/release/promise.js:564:21)
    at Promise._settlePromise0 (/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/node_modules/bluebird/js/release/promise.js:687:18)
    at Async._drainQueue (/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/node_modules/bluebird/js/release/async.js:138:16)
    at Async._drainQueues (/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/node_modules/bluebird/js/release/async.js:148:10)
    at Async.drainQueues (/Users/benjamincoe/npm-inc/registry-relational-service/node_modules/pgtools/node_modules/bluebird/js/release/async.js:17:14)
    at process._tickCallback (node.js:442:13)
npm ERR! Test failed.  See above for more details.```
``````
