### PR TITLE
allow choosing a template when providing a config as an Object

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ function createOrDropDatabase(action) {
 
       var escapedDbName = dbName.replace(/\"/g, '""');
       var sql = action + ' DATABASE "' + escapedDbName + '"';
+      if (config.template) sql += ' WITH TEMPLATE=' + config.template;
       client.query(sql, function (pgErr, res) {
         var err;
         if (pgErr) {


### PR DESCRIPTION
Sometimes the default template (template1) is in use by another user for some reason, so it  is handy to provide a different template when creating a database.