### PR TITLE
Update Node.js version to include LTS versions from v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: node_js
 node_js:
-  - "5"
   - "6"
+  - "8"
+  - "10"
+  - "12"
+  - "14"
+  - "lts/*"
   - "node"
 services:
   - postgresql

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ pgtools.createdb(config, 'test-db', function (err, res) {
 * `createdbjs`: which emulates pgtools' `createdb` functionality.
 * `dropdbjs`: which emulates pgtools' `dropdb` functionality.
 
+## Node.js support
+
+We support all LTS versions from 6 and up. We try to keep up with the latest Node.js version.
+
 ## Releasing
 
 Rather than manually running `npm version <patch|minor|major>`, instead run:


### PR DESCRIPTION
It makes sense to drop Node.js 5 from our supported versions. At the same time I added all Node.js LTS versions higher than 5 + the latest Node.js version.